### PR TITLE
Wait for content before parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,14 @@ Distributed under the MIT License. See `LICENSE` for more information.
 <!-- CONTACT -->
 ## Contact
 
+Quickest Response:
+
+[Discord Server](https://discord.gg/rV26FZ2upF): - https://discord.gg/rV26FZ2upF
+
+Slow Response:
+
 Discord: - Zarg#8467
+
 
 Project Link: [https://github.com/Zaarrg/TTVDropBot](https://github.com/Zaarrg/TTVDropBot)
 

--- a/src/Pages/StreamPage.js
+++ b/src/Pages/StreamPage.js
@@ -34,7 +34,7 @@ async function StreamPage(startch) {
     
     //Got to campaignpage
     await campaignpage.goto('https://www.twitch.tv/drops/campaigns', {waitUntil: ["domcontentloaded", "networkidle2"]});
-    await campaignpage.waitForSelector(".section.streamer-drops, .section.general-drops, .section.is-getstarted"); // wait for one of the drop classes; default timeout is 30s
+    await campaignpage.waitForSelector(`h3[title="Rust"]`); // default timeout is 30s
     
     //Check for 18+
     console.log(" ")

--- a/src/Pages/StreamPage.js
+++ b/src/Pages/StreamPage.js
@@ -27,13 +27,15 @@ async function StreamPage(startch) {
     await watchingpage.setCookie.apply(watchingpage, data.cookies);
     //Goto Selectetd Starting Ch
     await watchingpage.goto(startch)
+    
     //Goto Twitch inv
-    await dropspage.goto('https://www.twitch.tv/drops/inventory', {waitUntil: "networkidle2"})
-    await dropspage.reload({
-        waitUntil: ["networkidle2", "domcontentloaded"]
-    })
+    await dropspage.goto('https://www.twitch.tv/drops/inventory', {waitUntil: ["domcontentloaded", "networkidle2"]});
+    await dropspage.waitForSelector("main.twilight-main > div.root-scrollable"); // default timeout is 30s
+    
     //Got to campaignpage
-    await campaignpage.goto('https://www.twitch.tv/drops/campaigns', {waitUntil: "networkidle2"})
+    await campaignpage.goto('https://www.twitch.tv/drops/campaigns', {waitUntil: ["domcontentloaded", "networkidle2"]});
+    await campaignpage.waitForSelector(".section.streamer-drops, .section.general-drops, .section.is-getstarted"); // wait for one of the drop classes; default timeout is 30s
+    
     //Check for 18+
     console.log(" ")
     console.log(chalk.gray("Setting Video Settings like Quality and Volume..."))

--- a/src/Pages/WatchingPage.js
+++ b/src/Pages/WatchingPage.js
@@ -54,7 +54,8 @@ async function Watch() {
             console.log(chalk.gray('Getting all Drops and other Details'))
 
             //Go to Rust Twitch Drops
-            await page.goto(data.rustdrops, {waitUntil: ["networkidle2"]})
+            await page.goto(data.rustdrops, {waitUntil: ["domcontentloaded", "networkidle2"]});
+            await page.waitForSelector(`h3[title="Rust"]`, { timeout: 10000 }); // wait for 10s
 
             //Get Rust Drops From Rust Site
             await GetRustDrops(page, undefined,true).then(async r => {


### PR DESCRIPTION
Added a few `waitForSelector` calls to avoid invalid results after parsing the pages.