### PR TITLE
Docker container support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,74 @@
+name: Docker
+
+on:
+  push:
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: ttvdropbot
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:16-buster-slim as compiler
+WORKDIR /usr/src/app
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends gnutls-bin git ca-certificates
+COPY . .
+RUN npm install
+RUN npm run build
+
+FROM node:16-buster-slim as runner
+WORKDIR /usr/src/app/
+COPY --from=compiler /usr/src/app/package*.json ./
+COPY --from=compiler /usr/src/app/build ./build
+RUN npm ci --production
+RUN npm cache clean --force
+RUN npm install
+ENV NODE_ENV="production"
+CMD [ "npm", "start" ]

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,23 @@
    OR
     npm run start:dev
     ```
+
+<h3 align="center">Docker</h3>
+
+1. Get your auth token
+    ```bash
+    docker run --rm -it ghcr.io/zaarrg/ttvdropbot/ttvdropbot:latest node ./build/index.js --showtoken
+    ```
+2. Login to Twitch, copy your auth token, and then exit the container with `Ctrl + C`
+3. Create the container
+    ```bash
+    docker run -d --name ttvdropbot \
+    -e ttvdropbot_displayless=true \
+    -e ttvdropbot_token=TokenFromStep1 \
+    -e ttvdropbot_games="Sea_of_Thieves Rust Lost_Ark No_Man's_Sky" \
+    -e ttvdropbot_autoclaim=true \
+    ghcr.io/zaarrg/ttvdropbot/ttvdropbot:latest
+    ```
 ---
 
 ## 📚 **How to use the Bot?**


### PR DESCRIPTION
Pretty straight forward request. This is how I am running my containers personally.

Dockerfile builds from source, then takes the build product into the final image.

All builds are automated by GitHub Actions on commit to main, or on a new tag. If a tag, then the image is built with that tag instead of just "latest". (ie. ttvdropbot:2.0.0.3). All images are hosted by GitHub, accessible from the Packages section of the repo.

A quick how-to has been added to the readme for Docker.