### PR TITLE
Don't claim channel points since it's not working

### DIFF
--- a/src/Checks/pointsCheck.ts
+++ b/src/Checks/pointsCheck.ts
@@ -14,7 +14,7 @@ export async function pointsCheck(channelLogin: string) {
     points = pointsrequest[0].data.community.channel.self.communityPoints.balance
     let channelID = pointsrequest[0].data.community.id
 
-    await checkisClaimeable(pointsrequest, channelID)
+    // await checkisClaimeable(pointsrequest, channelID)
     return points
 }
 


### PR DESCRIPTION
This is a fix for #74 where channel points wouldn't collect properly and then cause the program to crash.

I'm running this variant locally and it's not running into the problem of the release. Just removing this feature fixes this crash